### PR TITLE
extension for nvidia-gpu-operator extension

### DIFF
--- a/deployment-package/common/registry-nvidia-ncg.yaml
+++ b/deployment-package/common/registry-nvidia-ncg.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+# SPDX-License-Identifier: LicenseRef-Intel
+---
+specSchema: "Registry"
+schemaVersion: "0.1"
+$schema: "https://schema.intel.com/catalog.orchestrator/0.1/schema"
+
+name: nvidia-ncg
+description: "nvidia-ncg Registry"
+type: "HELM"
+
+rootUrl: "https://helm.ngc.nvidia.com/nvidia"

--- a/deployment-package/nvidia-gpu-operator/nvidia-gpu-operator-application.yaml
+++ b/deployment-package/nvidia-gpu-operator/nvidia-gpu-operator-application.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: (C) 2024 Intel Corporation
+# SPDX-License-Identifier: LicenseRef-Intel
+---
+specSchema: "Application"
+schemaVersion: "0.1"
+$schema: "https://schema.intel.com/catalog.orchestrator/0.1/schema"
+
+name: nvidia-gpu-operator-app
+version: 0.0.1
+description: nvidia gpu operator application
+
+helmRegistry: nvidia-ncg
+chartName: gpu-operator
+chartVersion: v25.3.0
+
+profiles:
+  - name: default
+    valuesFileName: nvidia-gpu-operator-values.yaml

--- a/deployment-package/nvidia-gpu-operator/nvidia-gpu-operator-deployment-package.yaml
+++ b/deployment-package/nvidia-gpu-operator/nvidia-gpu-operator-deployment-package.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: (C) 2024 Intel Corporation
+# SPDX-License-Identifier: LicenseRef-Intel
+---
+specSchema: "DeploymentPackage"
+schemaVersion: "0.1"
+$schema: "https://schema.intel.com/catalog.orchestrator/0.1/schema"
+
+name: nvidia-gpu-operator
+displayName: NVIDIA GPU Operator deployment package
+description: NVIDIA GPU Operator deployment package
+version: 0.0.1
+forbidsMultipleDeployments: true
+kind: extension
+
+applications:
+  - name: nvidia-gpu-operator-app
+    version: 0.0.1
+
+defaultNamespaces:
+  nvidia-gpu-operator-app: gpu-operator
+
+deploymentProfiles:
+  - name: default
+    applicationProfiles:
+      - application: nvidia-gpu-operator-app
+        profile: default
+
+namespaces:
+  - name: gpu-operator
+    labels:
+      pod-security.kubernetes.io/enforce: privileged
+      name: gpu-operator

--- a/deployment-package/nvidia-gpu-operator/nvidia-gpu-operator-values.yaml
+++ b/deployment-package/nvidia-gpu-operator/nvidia-gpu-operator-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: (C) 2024 Intel Corporation
+# SPDX-License-Identifier: LicenseRef-Intel
+---
+driver:
+  env:
+    - name: http_proxy
+      value: "http://proxy-dmz.intel.com:912"
+    - name: https_proxy
+      value: "http://proxy-dmz.intel.com:912"
+toolkit:
+  env:
+    - name: CONTAINERD_CONFIG
+      value: /var/lib/rancher/rke2/agent/etc/containerd/config.toml
+    - name: CONTAINERD_SOCKET
+      value: /run/k3s/containerd/containerd.sock
+    - name: CONTAINERD_RUNTIME_CLASS
+      value: nvidia
+    - name: CONTAINERD_SET_AS_DEFAULT
+      value: "true"


### PR DESCRIPTION
## Description

This PR holds the changes for new extension to install the 'nvidia-gpu-operator'
Which enable the cluster to have nvidia gpu capability.

## Changes

- application.yaml
- deployment-package
- values.yaml
- registry yaml

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
