### PR TITLE
ci: Use `run_artifact_push` in post-merge CI

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -26,7 +26,7 @@ jobs:
       run_build: false
       run_helm_build: true
       run_helm_push: true
-      run_artifact: true
+      run_artifact_push: true
     secrets:
       SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
       COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}


### PR DESCRIPTION
## Description

Adapt to changes from https://github.com/open-edge-platform/orch-ci/pull/175 and https://github.com/open-edge-platform/orch-ci/pull/176

## Changes

List the changes you have made.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
