### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -18,3 +20,5 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request introduces a cooldown period to the Dependabot configuration for both Go modules and GitHub Actions updates. This helps reduce the frequency of pull requests by spacing them out.

Dependabot configuration enhancements:

* Added a `cooldown` section with `default-days: 7` to both the Go modules and GitHub Actions update configurations in `.github/dependabot.yml` to limit update PRs to at most once every seven days.